### PR TITLE
Customize output with template

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,17 +18,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.x
-      - name: Setup env
-        # https://github.com/actions/setup-go/issues/14
-        run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
-        shell: bash
+          go-version: '^1.16'
       - name: Test
         run: make test
       - name: Lint

--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ $ echo 'feature/1234_foo-bar' | buranko
 
 Configuration uses 'git-config' variables.
 
+***buranko.template***
+
+The template can use the values defined in the following Fields.
+
+This option is useful for pointing to issues in other GitHub repositories, or for software that requires a prefix in the issue number.
+
+```
+$ git checkout -b feature/1234_foo-bar
+$ git config buranko.template ABC-{{.ID}}
+$ buranko -template
+ABC-1234
+$ git config buranko.template foo-org/bar-repo#{{.ID}}
+$ buranko -template
+foo-org/bar-repo#1234
+```
+
 ***buranko.reponame***
 
 A repository name.
@@ -81,7 +97,7 @@ Add an issue ID to commit comment using git hook.
 ```sh
 if [ "$2" == "" ]; then
     mv $1 $1.tmp
-    echo `buranko -ref -reponame` > $1
+    echo `buranko -template -ref -reponame` > $1
     cat $1.tmp >> $1
 fi
 ```

--- a/git.go
+++ b/git.go
@@ -18,3 +18,16 @@ func GetRepoName() string {
 
 	return strings.TrimRight(string(out), "\n")
 }
+
+// GetTemplate returns a configured template.
+func GetTemplate() string {
+	out, err := pipeline.Output(
+		[]string{"git", "config", "--get", "buranko.template"},
+	)
+
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimRight(string(out), "\n")
+}

--- a/main.go
+++ b/main.go
@@ -15,9 +15,10 @@ import (
 const Version string = "1.0.0"
 
 var (
-	output   string
-	ref      bool
-	reponame bool
+	output      string
+	ref         bool
+	reponame    bool
+	useTemplate bool
 )
 
 // A Command is an implementation of a buranko command
@@ -65,6 +66,7 @@ func main() {
 	flag.StringVar(&output, "output", "ID", "Output field")
 	flag.BoolVar(&ref, "ref", false, "Add reference mark")
 	flag.BoolVar(&reponame, "reponame", false, "Add repository name")
+	flag.BoolVar(&useTemplate, "template", false, "Use the configured template in the output")
 	flag.Usage = usage
 	flag.Parse()
 	log.SetFlags(0)
@@ -107,6 +109,9 @@ Options:
 
     -reponame
         Output a repository name before ID field.
+
+    -template
+        Use the configured template in the output.
 `
 
 var helpTemplate = `usage: buranko {{.UsageLine}}
@@ -176,6 +181,20 @@ func doOutput() {
 	}
 
 	branch := Parse(branchName)
+
+	templateText := GetTemplate()
+	if useTemplate && len(templateText) > 0 {
+		tmpl, err := template.New("Format").Parse(templateText)
+		if err != nil {
+			log.Fatal(err)
+		}
+		writer := new(strings.Builder)
+		tmpl.Execute(writer, branch)
+
+		fmt.Print(writer.String())
+
+		return
+	}
 
 	switch output {
 	case "FullName":


### PR DESCRIPTION
Customize output with template.

This option is useful for pointing to issues in other GitHub repositories, or for software that requires a prefix in the issue number.

```
$ git checkout -b feature/1234_foo-bar
$ git config buranko.template ABC-{{.ID}}
$ buranko -template
ABC-1234
$ git config buranko.template foo-org/bar-repo#{{.ID}}
$ buranko -template
foo-org/bar-repo#1234
```