### PR TITLE
Add LinkID to output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ foo-org/bar-repo#1234
 * `FullName`: Full branch name
 * `Action`: Action type
 * `ID`: Issue ID
+* `LinkID`: Issue ID with a leading `#`
 * `Description`: Description
 
 ## Parse patterns
@@ -64,6 +65,7 @@ foo-org/bar-repo#1234
 * `FullName`: `feature/1234_foo-bar`
 * `Action`: `feature`
 * `ID`: `1234`
+* `LinkID`: `#1234`
 * `Description`: `foo-bar`
 
 ### `foo-bar`

--- a/branch.go
+++ b/branch.go
@@ -24,3 +24,9 @@ func NewBranch() *Branch {
 		Description: description,
 	}
 }
+
+// LinkID returns ID with a leading #
+// This can be used to link the issue ID to the commit message
+func (b *Branch) LinkID() string {
+	return "#" + b.ID
+}

--- a/branch_test.go
+++ b/branch_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestBranch_LinkID(t *testing.T) {
+	branch := NewBranch()
+	branch.ID = "1234"
+	expected := "#1234"
+
+	if branch.LinkID() != expected {
+		t.Fatalf("Expected %v, but %v:", expected, branch.LinkID())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version returns release version
-const Version string = "1.0.0"
+const Version string = "2.0.0"
 
 var (
 	output      string

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ The commands are:
 Options:
     -output
         Specify an output field.
-        Available fields are FullName, Action, ID, Description.
+        Available fields are FullName, Action, ID, LinkID, Description.
 
     -ref
         Add a reference mark (#) when output ID field.
@@ -206,6 +206,8 @@ func doOutput() {
 		}
 
 		fmt.Print(strings.Join(output, ""))
+	case "LinkID":
+		fmt.Print(branch.LinkID())
 	case "Description":
 		fmt.Print(branch.Description)
 	default:


### PR DESCRIPTION
For example, if the ID is `1234`, this option will output `#1234`
This can be used to link the issue ID to the commit message.