### PR TITLE
Remove ref option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ A tool for parse a git branch name
 $ git checkout -b feature/1234_foo-bar
 $ buranko
 1234
-$ buranko -ref
-#1234
 ```
 
 Specify an output field.
 
 ```
+$ buranko -output LinkID
+#1234
 $ buranko -output Name
 foo-bar
 ```
@@ -84,7 +84,7 @@ Add an issue ID to commit comment using git hook.
 ```sh
 if [ "$2" == "" ]; then
     mv $1 $1.tmp
-    echo `buranko -template -ref` > $1
+    echo `buranko -output LinkID -template` > $1
     cat $1.tmp >> $1
 fi
 ```

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ const Version string = "2.0.0"
 
 var (
 	output      string
-	ref         bool
 	useTemplate bool
 )
 
@@ -63,7 +62,6 @@ var commands = []*Command{}
 
 func main() {
 	flag.StringVar(&output, "output", "ID", "Output field")
-	flag.BoolVar(&ref, "ref", false, "Add reference mark")
 	flag.BoolVar(&useTemplate, "template", false, "Use the configured template in the output")
 	flag.Usage = usage
 	flag.Parse()
@@ -101,9 +99,6 @@ Options:
     -output
         Specify an output field.
         Available fields are FullName, Action, ID, LinkID, Description.
-
-    -ref
-        Add a reference mark (#) when output ID field.
 
     -template
         Use the configured template in the output.
@@ -197,15 +192,7 @@ func doOutput() {
 	case "Action":
 		fmt.Print(branch.Action)
 	case "ID":
-		output := []string{}
-
-		if ref && len(branch.ID) > 0 {
-			output = append(output, "#"+branch.ID)
-		} else {
-			output = append(output, branch.ID)
-		}
-
-		fmt.Print(strings.Join(output, ""))
+		fmt.Print(branch.ID)
 	case "LinkID":
 		fmt.Print(branch.LinkID())
 	case "Description":


### PR DESCRIPTION
The same can be done with the `-output LinkID` option.