### PR TITLE
Use std.io.IsTerminal instead of atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,17 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,7 +71,6 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 name = "buranko"
 version = "3.0.0"
 dependencies = [
- "atty",
  "clap",
  "git2",
  "regex",
@@ -185,15 +173,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "icu_collections"
@@ -612,28 +591,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2024"
 clap = { version = "4.5.32", features = ["derive"] }
 git2 = "0.20.1"
 regex = "1.10.3"
-atty = "0.2.14"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use git2::Repository;
-use std::io::{self, Read};
+use std::io::{self, IsTerminal, Read};
 
 mod branch;
 use branch::Branch;
@@ -63,7 +63,7 @@ fn main() {
     let args = Args::parse();
 
     // Check if input is coming from a pipe
-    let branch = if !atty::is(atty::Stream::Stdin) {
+    let branch = if !io::stdin().is_terminal() {
         // Read from stdin
         match read_from_stdin() {
             Ok(input) => Branch::parse(&input),


### PR DESCRIPTION
- Use `std.io.IsTerminal` instead of atty